### PR TITLE
Account privileges

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/ModuleLength:
   Max: 150
 
 Metrics/ParameterLists:
-  Max: 6
+  Max: 8
 
 Style/FileName:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/ModuleLength:
   Max: 150
 
 Metrics/ParameterLists:
-  Max: 8
+  Max: 6
 
 Style/FileName:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -260,16 +260,19 @@ logs = client.get_log(severity_level, duration, log_type)
 username = 'Administrator'
 client.get_account_privileges(username)
 
-# Set the Account Privileges for a specific user:
-login = true
-remote_console = false
-user_config = true
-virtual_media = false
-virtual_power_and_reset = true
-ilo_config = false
+# Set the Login Privilege to true for a specific user:
+client.set_account_privileges(username, LoginPriv: true)
 
-client.set_account_privileges(username, login, remote_console, user_config, virtual_media,
-  virtual_power_and_reset, ilo_config)
+# Set all of the Account Privileges for a specific user:
+privileges = {
+  'LoginPriv' => true,
+  'RemoteConsolePriv' => true,
+  'UserConfigPriv' => true,
+  'VirtualMediaPriv' => true,
+  'VirtualPowerAndResetPriv' => true,
+  'iLOConfigPriv' => true
+}
+client.set_account_privileges(username, privileges)
 ```
 
 #### Manager Network Protocol

--- a/README.md
+++ b/README.md
@@ -254,6 +254,24 @@ duration = 10 # hours
 logs = client.get_log(severity_level, duration, log_type)
 ```
 
+### Manager Account
+```ruby
+# Get the Account Privileges for a specific user:
+username = 'Administrator'
+client.get_account_privileges(username)
+
+# Set the Account Privileges for a specific user:
+login = true
+remote_console = false
+user_config = true
+virtual_media = false
+virtual_power_and_reset = true
+ilo_config = false
+
+client.set_account_privileges(username, login, remote_console, user_config, virtual_media,
+  virtual_power_and_reset, ilo_config)
+```
+
 #### Manager Network Protocol
 ```ruby
 # Get the minutes until session timeout:

--- a/lib/ilo-sdk/client.rb
+++ b/lib/ilo-sdk/client.rb
@@ -55,6 +55,7 @@ module ILO_SDK
     include PowerHelper
     include AccountServiceHelper
     include LogEntryHelper
+    include ManagerAccountHelper
     include SecureBootHelper
     include BiosHelper
     include BootSettingsHelper

--- a/lib/ilo-sdk/helpers/bios_helper.rb
+++ b/lib/ilo-sdk/helpers/bios_helper.rb
@@ -32,7 +32,7 @@ module ILO_SDK
 
     # Get the UEFI shell start up
     # @raise [RuntimeError] if the request failed
-    # @return [String] uefi_shell_startup
+    # @return [Hash] uefi_shell_startup
     def get_uefi_shell_startup
       response = rest_get('/redfish/v1/Systems/1/bios/Settings/')
       bios = response_handler(response)

--- a/lib/ilo-sdk/helpers/manager_account_helper.rb
+++ b/lib/ilo-sdk/helpers/manager_account_helper.rb
@@ -17,7 +17,7 @@ module ILO_SDK
     # @raise [RuntimeError] if the request failed
     # @return [Hash] privileges
     def get_account_privileges(username)
-      response = rest_get("/redfish/v1/AccountService/")
+      response = rest_get('/redfish/v1/AccountService/Accounts/')
       accounts = response_handler(response)['Items']
       accounts.each do |account|
         if account['Oem']['Hp']['LoginName'] == username
@@ -37,7 +37,7 @@ module ILO_SDK
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_account_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
-      response = rest_get('/redfish/v1/AccountService/')
+      response = rest_get('/redfish/v1/AccountService/Accounts/')
       accounts = response_handler(response)['Items']
       id = '0'
       accounts.each do |account|
@@ -60,7 +60,7 @@ module ILO_SDK
           }
         }
       }
-      reponse = rest_patch("/redfish/v1/AccountService/#{id}/", body: new_action)
+      response = rest_patch("/redfish/v1/AccountService/Accounts/#{id}/", body: new_action)
       response_handler(response)
       true
     end

--- a/lib/ilo-sdk/helpers/manager_account_helper.rb
+++ b/lib/ilo-sdk/helpers/manager_account_helper.rb
@@ -26,17 +26,12 @@ module ILO_SDK
       end
     end
 
-    # Set the UEFI shell start up
+    # Set the privileges for a user
     # @param [TrueClass, FalseClass] username
-    # @param [TrueClass, FalseClass] login
-    # @param [TrueClass, FalseClass] remote_console
-    # @param [TrueClass, FalseClass] user_config
-    # @param [TrueClass, FalseClass] virtual_media
-    # @param [TrueClass, FalseClass] virtual_media_power_and_reset
-    # @param [TrueClass, FalseClass] ilo_config
+    # @param [Hash] privileges
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_account_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
+    def set_account_privileges(username, privileges)
       response = rest_get('/redfish/v1/AccountService/Accounts/')
       accounts = response_handler(response)['Items']
       id = '0'
@@ -49,14 +44,7 @@ module ILO_SDK
       new_action = {
         'Oem' => {
           'Hp' => {
-            'Privileges' => {
-              'LoginPriv' => login,
-              'RemoteConsolePriv' => remote_console,
-              'UserConfigPriv' => user_config,
-              'VirtualMediaPriv' => virtual_media,
-              'VirtualPowerAndResetPriv' => virtual_power_and_reset,
-              'iLOConfigPriv' => ilo_config
-            }
+            'Privileges' => privileges
           }
         }
       }

--- a/lib/ilo-sdk/helpers/manager_account_helper.rb
+++ b/lib/ilo-sdk/helpers/manager_account_helper.rb
@@ -29,6 +29,12 @@ module ILO_SDK
     # Set the privileges for a user
     # @param [TrueClass, FalseClass] username
     # @param [Hash] privileges
+    # @option privileges [TrueClass, FalseClass] :LoginPriv
+    # @option privileges [TrueClass, FalseClass] :RemoteConsolePriv
+    # @option privileges [TrueClass, FalseClass] :UserConfigPriv
+    # @option privileges [TrueClass, FalseClass] :VirtualMediaPriv
+    # @option privileges [TrueClass, FalseClass] :VirtualPowerAndResetPriv
+    # @option privileges [TrueClass, FalseClass] :iLOConfigPriv
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_account_privileges(username, privileges)

--- a/lib/ilo-sdk/helpers/manager_account_helper.rb
+++ b/lib/ilo-sdk/helpers/manager_account_helper.rb
@@ -1,0 +1,68 @@
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module ILO_SDK
+  # Contains helper methods for Manager Account actions
+  module ManagerAccountHelper
+    # Get the Privileges for a user
+    # @param [String, Symbol] username
+    # @raise [RuntimeError] if the request failed
+    # @return [Hash] privileges
+    def get_privileges(username)
+      response = rest_get("/redfish/v1/AccountService/")
+      accounts = response_handler(response)['Items']
+      accounts.each do |account|
+        if account['Oem']['Hp']['LoginName'] == username
+          return account['Oem']['Hp']['Privileges']
+        end
+      end
+    end
+
+    # Set the UEFI shell start up
+    # @param [TrueClass, FalseClass] username
+    # @param [TrueClass, FalseClass] login
+    # @param [TrueClass, FalseClass] remote_console
+    # @param [TrueClass, FalseClass] user_config
+    # @param [TrueClass, FalseClass] virtual_media
+    # @param [TrueClass, FalseClass] virtual_media_power_and_reset
+    # @param [TrueClass, FalseClass] ilo_config
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
+      response = rest_get('/redfish/v1/AccountService/')
+      accounts = response_handler(response)['Items']
+      id = '0'
+      accounts.each do |account|
+        if account['Oem']['Hp']['LoginName'] == username
+          id = account['Id']
+          break
+        end
+      end
+      new_action = {
+        'Oem' => {
+          'Hp' => {
+            'Privileges' => {
+              'LoginPriv' => login,
+              'RemoteConsolePriv' => remote_console,
+              'UserConfigPriv' => user_config,
+              'VirtualMediaPriv' => virtual_media,
+              'VirtualPowerAndResetPriv' => virtual_power_and_reset,
+              'iLOConfigPriv' => ilo_config
+            }
+          }
+        }
+      }
+      reponse = rest_patch("/redfish/v1/AccountService/#{id}/", body: new_action)
+      response_handler(response)
+      true
+    end
+  end
+end

--- a/lib/ilo-sdk/helpers/manager_account_helper.rb
+++ b/lib/ilo-sdk/helpers/manager_account_helper.rb
@@ -16,7 +16,7 @@ module ILO_SDK
     # @param [String, Symbol] username
     # @raise [RuntimeError] if the request failed
     # @return [Hash] privileges
-    def get_privileges(username)
+    def get_account_privileges(username)
       response = rest_get("/redfish/v1/AccountService/")
       accounts = response_handler(response)['Items']
       accounts.each do |account|
@@ -36,7 +36,7 @@ module ILO_SDK
     # @param [TrueClass, FalseClass] ilo_config
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
+    def set_account_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
       response = rest_get('/redfish/v1/AccountService/')
       accounts = response_handler(response)['Items']
       id = '0'

--- a/lib/ilo-sdk/version.rb
+++ b/lib/ilo-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module ILO_SDK
-  VERSION = '1.0.2'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/unit/helpers/manager_account_spec.rb
+++ b/spec/unit/helpers/manager_account_spec.rb
@@ -3,25 +3,7 @@ require_relative './../../spec_helper'
 RSpec.describe ILO_SDK::Client do
   include_context 'shared context'
 
-  # describe '#get_power_state' do
-  #   it 'makes a GET rest call' do
-  #     fake_response = FakeResponse.new('PowerState' => 'On')
-  #     expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/').and_return(fake_response)
-  #     power_state = @client.get_power_state
-  #     expect(power_state).to eq('On')
-  #   end
-  # end
-  #
-  # describe '#set_power_state' do
-  #   it 'makes a POST rest call' do
-  #     new_action = { 'Action' => 'Reset', 'ResetType' => 'ForceRestart' }
-  #     expect(@client).to receive(:rest_post).with('/redfish/v1/Systems/1/', body: new_action).and_return(FakeResponse.new)
-  #     ret_val = @client.set_power_state('ForceRestart')
-  #     expect(ret_val).to eq(true)
-  #   end
-  # end
-
-  describe '#get_privileges' do
+  describe '#get_account_privileges' do
     it 'makes a GET rest call' do
       body = {
         'Items' => [
@@ -61,12 +43,12 @@ RSpec.describe ILO_SDK::Client do
       }
       fake_response = FakeResponse.new(body)
       expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/').and_return(fake_response)
-      privileges = @client.get_privileges('test1')
+      privileges = @client.get_account_privileges('test1')
       expect(privileges).to eq(body['Items'][0]['Oem']['Hp']['Privileges'])
     end
   end
 
-  describe '#set_privileges' do
+  describe '#set_account_privileges' do
     it 'makes a GET and a PATCH rest call' do
       body = {
         'Items' => [
@@ -106,7 +88,6 @@ RSpec.describe ILO_SDK::Client do
       }
       fake_response = FakeResponse.new(body)
       expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/').and_return(fake_response)
-      # username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config
       username = 'test1'
       login = false
       remote_console = false
@@ -129,7 +110,7 @@ RSpec.describe ILO_SDK::Client do
         }
       }
       expect(@client).to receive(:rest_patch).with('/redfish/v1/AccountService/1/', body: new_action).and_return(FakeResponse.new)
-      ret_val = @client.set_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
+      ret_val = @client.set_account_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
       expect(ret_val).to eq(true)
     end
   end

--- a/spec/unit/helpers/manager_account_spec.rb
+++ b/spec/unit/helpers/manager_account_spec.rb
@@ -1,0 +1,136 @@
+require_relative './../../spec_helper'
+
+RSpec.describe ILO_SDK::Client do
+  include_context 'shared context'
+
+  # describe '#get_power_state' do
+  #   it 'makes a GET rest call' do
+  #     fake_response = FakeResponse.new('PowerState' => 'On')
+  #     expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/').and_return(fake_response)
+  #     power_state = @client.get_power_state
+  #     expect(power_state).to eq('On')
+  #   end
+  # end
+  #
+  # describe '#set_power_state' do
+  #   it 'makes a POST rest call' do
+  #     new_action = { 'Action' => 'Reset', 'ResetType' => 'ForceRestart' }
+  #     expect(@client).to receive(:rest_post).with('/redfish/v1/Systems/1/', body: new_action).and_return(FakeResponse.new)
+  #     ret_val = @client.set_power_state('ForceRestart')
+  #     expect(ret_val).to eq(true)
+  #   end
+  # end
+
+  describe '#get_privileges' do
+    it 'makes a GET rest call' do
+      body = {
+        'Items' => [
+          {
+            'Id' => '1',
+            'Oem' => {
+              'Hp' => {
+                'LoginName' => 'test1',
+                'Privileges' => {
+                  'LoginPriv' => true,
+                  'RemoteConsolePriv' => true,
+                  'UserConfigPriv' => true,
+                  'VirtualMediaPriv' => true,
+                  'VirtualPowerAndResetPriv' => true,
+                  'iLOConfigPriv' => true
+                }
+              }
+            }
+          },
+          {
+            'Id' => '2',
+            'Oem' => {
+              'Hp' => {
+                'LoginName' => 'test2',
+                'Privileges' => {
+                  'LoginPriv' => false,
+                  'RemoteConsolePriv' => false,
+                  'UserConfigPriv' => false,
+                  'VirtualMediaPriv' => false,
+                  'VirtualPowerAndResetPriv' => false,
+                  'iLOConfigPriv' => false
+                }
+              }
+            }
+          }
+        ]
+      }
+      fake_response = FakeResponse.new(body)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/').and_return(fake_response)
+      privileges = @client.get_privileges('test1')
+      expect(privileges).to eq(body['Items'][0]['Oem']['Hp']['Privileges'])
+    end
+  end
+
+  describe '#set_privileges' do
+    it 'makes a GET and a PATCH rest call' do
+      body = {
+        'Items' => [
+          {
+            'Id' => '1',
+            'Oem' => {
+              'Hp' => {
+                'LoginName' => 'test1',
+                'Privileges' => {
+                  'LoginPriv' => true,
+                  'RemoteConsolePriv' => true,
+                  'UserConfigPriv' => true,
+                  'VirtualMediaPriv' => true,
+                  'VirtualPowerAndResetPriv' => true,
+                  'iLOConfigPriv' => true
+                }
+              }
+            }
+          },
+          {
+            'Id' => '2',
+            'Oem' => {
+              'Hp' => {
+                'LoginName' => 'test2',
+                'Privileges' => {
+                  'LoginPriv' => false,
+                  'RemoteConsolePriv' => false,
+                  'UserConfigPriv' => false,
+                  'VirtualMediaPriv' => false,
+                  'VirtualPowerAndResetPriv' => false,
+                  'iLOConfigPriv' => false
+                }
+              }
+            }
+          }
+        ]
+      }
+      fake_response = FakeResponse.new(body)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/').and_return(fake_response)
+      # username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config
+      username = 'test1'
+      login = false
+      remote_console = false
+      user_config = false
+      virtual_media = false
+      virtual_power_and_reset = false
+      ilo_config = false
+      new_action = {
+        'Oem' => {
+          'Hp' => {
+            'Privileges' => {
+              'LoginPriv' => login,
+              'RemoteConsolePriv' => remote_console,
+              'UserConfigPriv' => user_config,
+              'VirtualMediaPriv' => virtual_media,
+              'VirtualPowerAndResetPriv' => virtual_power_and_reset,
+              'iLOConfigPriv' => ilo_config
+            }
+          }
+        }
+      }
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/AccountService/1/', body: new_action).and_return(FakeResponse.new)
+      ret_val = @client.set_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
+      expect(ret_val).to eq(true)
+    end
+  end
+end

--- a/spec/unit/helpers/manager_account_spec.rb
+++ b/spec/unit/helpers/manager_account_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ILO_SDK::Client do
         ]
       }
       fake_response = FakeResponse.new(body)
-      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/').and_return(fake_response)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/Accounts/').and_return(fake_response)
       privileges = @client.get_account_privileges('test1')
       expect(privileges).to eq(body['Items'][0]['Oem']['Hp']['Privileges'])
     end
@@ -87,7 +87,7 @@ RSpec.describe ILO_SDK::Client do
         ]
       }
       fake_response = FakeResponse.new(body)
-      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/').and_return(fake_response)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/Accounts/').and_return(fake_response)
       username = 'test1'
       login = false
       remote_console = false
@@ -109,7 +109,7 @@ RSpec.describe ILO_SDK::Client do
           }
         }
       }
-      expect(@client).to receive(:rest_patch).with('/redfish/v1/AccountService/1/', body: new_action).and_return(FakeResponse.new)
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/AccountService/Accounts/1/', body: new_action).and_return(FakeResponse.new)
       ret_val = @client.set_account_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
       expect(ret_val).to eq(true)
     end

--- a/spec/unit/helpers/manager_account_spec.rb
+++ b/spec/unit/helpers/manager_account_spec.rb
@@ -89,28 +89,80 @@ RSpec.describe ILO_SDK::Client do
       fake_response = FakeResponse.new(body)
       expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/Accounts/').and_return(fake_response)
       username = 'test1'
-      login = false
-      remote_console = false
-      user_config = false
-      virtual_media = false
-      virtual_power_and_reset = false
-      ilo_config = false
+      privileges = {
+        'LoginPriv' => false,
+        'RemoteConsolePriv' => false,
+        'UserConfigPriv' => false,
+        'VirtualMediaPriv' => false,
+        'VirtualPowerAndResetPriv' => false,
+        'iLOConfigPriv' => false
+      }
       new_action = {
         'Oem' => {
           'Hp' => {
-            'Privileges' => {
-              'LoginPriv' => login,
-              'RemoteConsolePriv' => remote_console,
-              'UserConfigPriv' => user_config,
-              'VirtualMediaPriv' => virtual_media,
-              'VirtualPowerAndResetPriv' => virtual_power_and_reset,
-              'iLOConfigPriv' => ilo_config
-            }
+            'Privileges' => privileges
           }
         }
       }
       expect(@client).to receive(:rest_patch).with('/redfish/v1/AccountService/Accounts/1/', body: new_action).and_return(FakeResponse.new)
-      ret_val = @client.set_account_privileges(username, login, remote_console, user_config, virtual_media, virtual_power_and_reset, ilo_config)
+      ret_val = @client.set_account_privileges(username, privileges)
+      expect(ret_val).to eq(true)
+    end
+
+    it 'makes a GET and a PATCH (only on some attributes) rest call' do
+      body = {
+        'Items' => [
+          {
+            'Id' => '1',
+            'Oem' => {
+              'Hp' => {
+                'LoginName' => 'test1',
+                'Privileges' => {
+                  'LoginPriv' => true,
+                  'RemoteConsolePriv' => true,
+                  'UserConfigPriv' => true,
+                  'VirtualMediaPriv' => true,
+                  'VirtualPowerAndResetPriv' => true,
+                  'iLOConfigPriv' => true
+                }
+              }
+            }
+          },
+          {
+            'Id' => '2',
+            'Oem' => {
+              'Hp' => {
+                'LoginName' => 'test2',
+                'Privileges' => {
+                  'LoginPriv' => false,
+                  'RemoteConsolePriv' => false,
+                  'UserConfigPriv' => false,
+                  'VirtualMediaPriv' => false,
+                  'VirtualPowerAndResetPriv' => false,
+                  'iLOConfigPriv' => false
+                }
+              }
+            }
+          }
+        ]
+      }
+      fake_response = FakeResponse.new(body)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/AccountService/Accounts/').and_return(fake_response)
+      username = 'test1'
+      privileges = {
+        'LoginPriv' => false,
+        'RemoteConsolePriv' => false,
+        'UserConfigPriv' => false
+      }
+      new_action = {
+        'Oem' => {
+          'Hp' => {
+            'Privileges' => privileges
+          }
+        }
+      }
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/AccountService/Accounts/1/', body: new_action).and_return(FakeResponse.new)
+      ret_val = @client.set_account_privileges(username, privileges)
       expect(ret_val).to eq(true)
     end
   end


### PR DESCRIPTION
fixes #6 

Added a resource for `manager_account` to be consistent with API Docs.
This class allows you to get and set privileges for accounts.