### PR TITLE
updated bios to take hash arguments instead of specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,43 +70,47 @@ client.delete_user('user1')
 #### Bios
 ```ruby
 # Get BIOS base configuration:
-baseconfig = client.get_bios_baseconfig
+baseconfig = client.get_bios_settings(['BaseConfig'])['BaseConfig']
 
 # Revert BIOS:
 client.revert_bios
 
 # Get UEFI shell startup settings:
-uefi_shell_startup = client.get_uefi_shell_startup
+uefi_shell_startup = client.get_bios_settings(['UefiShellStartup', 'UefiShellStartupLocation', 'UefiShellStartupUrl'])
 
 # Set UEFI shell startup settings:
-uefi_shell_startup_location = 'Auto'
-uefi_shell_startup_url = 'http://wwww.uefi.com'
-client.uefi_shell_startup('Enabled', uefi_shell_startup_location, uefi_shell_startup_url)
+uefi = {
+  'UefiShallStartup' => 'Enabled',
+  'UefiShellStartupLocation' => 'Auto',
+  'UefiShellStartupUrl' => 'http://wwww.uefi.com'
+}
+client.set_bios_settings(uefi)
 
 # Get BIOS DHCP settings:
-bios_dhcp = client.get_bios_dhcp
+bios_dhcp = client.get_bios_settings(['Dhcpv4', 'Ipv4Address', 'Ipv4Gateway', 'Ipv4PrimaryDNS', 'Ipv4SecondaryDNS', 'Ipv4SubnetMask'])
 
 # Set BIOS DHCP settings:
-ipv4_address = '10.1.1.111'
-ipv4_gateway = '10.1.1.0'
-ipv4_primary_dns = '10.1.1.1'
-ipv4_secondary_dns = '10.1.1.2'
-ipv4_subnet_mark = '255.255.255.0'
-client.set_bios_dhcp('Disabled', ipv4_address, ipv4_gateway, ipv4_primary_dns, ipv4_secondary_dns, ipv4_subnet_mark)
+dhcp = {
+  'Dhcpv4' => 'Disabled',
+  'Ipv4Address' => '10.1.1.111',
+  'Ipv4Gateway' => '10.1.1.0',
+  'Ipv4PrimaryDNS' => '10.1.1.1',
+  'Ipv4SecondaryDNS' => '10.1.1.2',
+  'Ipv4SubnetMask' => '255.255.255.0'
+}
+client.set_bios_settings(dhcp)
 
 # Get the URL boot file:
-url_boot_file = client.get_url_boot_file
+url_boot_file = client.get_bios_settings(['UrlBootFile'])
 
 # Set the URL boot file:
-client.set_url_boot_file('http://www.urlbootfile.iso')
+client.set_bios_settings(UrlBootFile: 'http://www.urlbootfile.iso')
 
 # Get BIOS service settings:
-bios_service_settings = client.get_bios_service
+bios_service_settings = client.get_bios_settings(['ServiceName', 'ServiceEmail'])
 
 # Set BIOS service settings:
-service_name = 'my_name'
-service_email = 'my_name@hpe.com'
-client.set_bios_service(service_name, service_email)
+client.set_bios_settings(ServiceName: 'my_name', ServiceEmail: 'my_name@hpe.com')
 ```
 
 #### Boot Settings

--- a/lib/ilo-sdk/helpers/bios_helper.rb
+++ b/lib/ilo-sdk/helpers/bios_helper.rb
@@ -12,12 +12,25 @@
 module ILO_SDK
   # Contains helper methods for Bios actions
   module BiosHelper
-    # Get the bios base config
+    # Get the BIOS settings
+    # @param [Array] setting_names
     # @raise [RuntimeError] if the request failed
-    # @return [Fixnum] bios_baseconfig
-    def get_bios_baseconfig
+    # @return [Hash] bios_settings
+    def get_bios_settings(setting_names = nil)
       response = rest_get('/redfish/v1/Systems/1/bios/Settings/')
-      response_handler(response)['BaseConfig']
+      bios = response_handler(response)
+      return bios unless setting_names
+      bios.select { |key, _value| setting_names.include?(key) }
+    end
+
+    # Set the BIOS settings
+    # @param [Hash] bios
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_bios_settings(bios)
+      response = rest_patch('/redfish/v1/Systems/1/bios/Settings/', body: bios)
+      response_handler(response)
+      true
     end
 
     # Revert the BIOS
@@ -25,121 +38,6 @@ module ILO_SDK
     # @return true
     def revert_bios
       new_action = { 'BaseConfig' => 'default' }
-      response = rest_patch('/redfish/v1/systems/1/bios/Settings/', body: new_action)
-      response_handler(response)
-      true
-    end
-
-    # Get the UEFI shell start up
-    # @raise [RuntimeError] if the request failed
-    # @return [Hash] uefi_shell_startup
-    def get_uefi_shell_startup
-      response = rest_get('/redfish/v1/Systems/1/bios/Settings/')
-      bios = response_handler(response)
-      {
-        'UefiShellStartup' => bios['UefiShellStartup'],
-        'UefiShellStartupLocation' => bios['UefiShellStartupLocation'],
-        'UefiShellStartupUrl' => bios['UefiShellStartupUrl']
-      }
-    end
-
-    # Set the UEFI shell start up
-    # @param [String, Symbol] uefi_shell_startup
-    # @param [String, Symbol] uefi_shell_startup_location
-    # @param [String, Symbol] uefi_shell_startup_url
-    # @raise [RuntimeError] if the request failed
-    # @return true
-    def set_uefi_shell_startup(uefi_shell_startup, uefi_shell_startup_location, uefi_shell_startup_url)
-      new_action = {
-        'UefiShellStartup' => uefi_shell_startup,
-        'UefiShellStartupLocation' => uefi_shell_startup_location,
-        'UefiShellStartupUrl' => uefi_shell_startup_url
-      }
-      response = rest_patch('/redfish/v1/Systems/1/bios/Settings/', body: new_action)
-      response_handler(response)
-      true
-    end
-
-    # Get the BIOS DHCP
-    # @raise [RuntimeError] if the request failed
-    # @return [String] bios_dhcp
-    def get_bios_dhcp
-      response = rest_get('/redfish/v1/Systems/1/bios/Settings/')
-      bios = response_handler(response)
-      {
-        'Dhcpv4' => bios['Dhcpv4'],
-        'Ipv4Address' => bios['Ipv4Address'],
-        'Ipv4Gateway' => bios['Ipv4Gateway'],
-        'Ipv4PrimaryDNS' => bios['Ipv4PrimaryDNS'],
-        'Ipv4SecondaryDNS' => bios['Ipv4SecondaryDNS'],
-        'Ipv4SubnetMask' => bios['Ipv4SubnetMask']
-      }
-    end
-
-    # Set the BIOS DHCP
-    # @param [String, Symbol] dhcpv4
-    # @param [String, Symbol] ipv4_address
-    # @param [String, Symbol] ipv4_gateway
-    # @param [String, Symbol] ipv4_primary_dns
-    # @param [String, Symbol] ipv4_secondary_dns
-    # @param [String, Symbol] ipv4_subnet_mask
-    # @raise [RuntimeError] if the request failed
-    # @return true
-    def set_bios_dhcp(dhcpv4, ipv4_address = '', ipv4_gateway = '', ipv4_primary_dns = '', ipv4_secondary_dns = '', ipv4_subnet_mask = '')
-      new_action = {
-        'Dhcpv4' => dhcpv4,
-        'Ipv4Address' => ipv4_address,
-        'Ipv4Gateway' => ipv4_gateway,
-        'Ipv4PrimaryDNS' => ipv4_primary_dns,
-        'Ipv4SecondaryDNS' => ipv4_secondary_dns,
-        'Ipv4SubnetMask' => ipv4_subnet_mask
-      }
-      response = rest_patch('/redfish/v1/Systems/1/bios/Settings/', body: new_action)
-      response_handler(response)
-      true
-    end
-
-    # Get the URL boot file
-    # @raise [RuntimeError] if the request failed
-    # @return [String] url_boot_file
-    def get_url_boot_file
-      response = rest_get('/redfish/v1/Systems/1/bios/Settings/')
-      response_handler(response)['UrlBootFile']
-    end
-
-    # Set the URL boot file
-    # @param [String, Symbol] url_boot_file
-    # @raise [RuntimeError] if the request failed
-    # @return true
-    def set_url_boot_file(url_boot_file)
-      new_action = { 'UrlBootFile' => url_boot_file }
-      response = rest_patch('/redfish/v1/Systems/1/bios/Settings/', body: new_action)
-      response_handler(response)
-      true
-    end
-
-    # Get the BIOS service
-    # @raise [RuntimeError] if the request failed
-    # @return [String] bios_service
-    def get_bios_service
-      response = rest_get('/redfish/v1/Systems/1/bios/Settings/')
-      bios = response_handler(response)
-      {
-        'ServiceName' => bios['ServiceName'],
-        'ServiceEmail' => bios['ServiceEmail']
-      }
-    end
-
-    # Set the BIOS service
-    # @param [String, Symbol] name
-    # @param [String, Symbol] email
-    # @raise [RuntimeError] if the request failed
-    # @return true
-    def set_bios_service(name, email)
-      new_action = {
-        'ServiceName' => name,
-        'ServiceEmail' => email
-      }
       response = rest_patch('/redfish/v1/Systems/1/bios/Settings/', body: new_action)
       response_handler(response)
       true

--- a/lib/ilo-sdk/version.rb
+++ b/lib/ilo-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module ILO_SDK
-  VERSION = '1.1.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/unit/helpers/bios_spec.rb
+++ b/spec/unit/helpers/bios_spec.rb
@@ -3,137 +3,71 @@ require_relative './../../spec_helper'
 RSpec.describe ILO_SDK::Client do
   include_context 'shared context'
 
-  describe '#get_bios_baseconfig' do
+  describe '#get_bios_settings' do
     it 'makes a GET rest call' do
-      fake_response = FakeResponse.new('BaseConfig' => 'default')
+      body = {
+        'BaseConfig' => 'default',
+        'UefiShellStartup' => 'UefiShellStartup',
+        'UefiShellStartupLocation' => 'UefiShellStartupLocation',
+        'UefiShellStartupUrl' => 'UefiShellStartupUrl',
+        'Dhcpv4' => 'Enabled',
+        'Ipv4Address' => '0.0.0.0',
+        'Ipv4Gateway' => '0.0.0.0',
+        'Ipv4PrimaryDNS' => '0.0.0.0',
+        'Ipv4SecondaryDNS' => '0.0.0.0',
+        'Ipv4SubnetMask' => '0.0.0.0',
+        'ServiceName' => 'John Doe',
+        'ServiceEmail' => 'john.doe@hpe.com'
+      }
+      fake_response = FakeResponse.new(body)
       expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
-      base_config = @client.get_bios_baseconfig
-      expect(base_config).to eq('default')
+      bios = @client.get_bios_settings
+      expect(bios).to eq(body)
+    end
+
+    it 'makes a GET rest call' do
+      body = {
+        'BaseConfig' => 'default',
+        'UefiShellStartup' => 'UefiShellStartup',
+        'UefiShellStartupLocation' => 'UefiShellStartupLocation',
+        'UefiShellStartupUrl' => 'UefiShellStartupUrl',
+        'Dhcpv4' => 'Enabled',
+        'Ipv4Address' => '0.0.0.0',
+        'Ipv4Gateway' => '0.0.0.0',
+        'Ipv4PrimaryDNS' => '0.0.0.0',
+        'Ipv4SecondaryDNS' => '0.0.0.0',
+        'Ipv4SubnetMask' => '0.0.0.0',
+        'ServiceName' => 'John Doe',
+        'ServiceEmail' => 'john.doe@hpe.com'
+      }
+      fake_response = FakeResponse.new(body)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
+      bios = @client.get_bios_settings(%w(UefiShellStartup UefiShellStartupLocation UefiShellStartupUrl))
+      expect(bios).to eq(
+        'UefiShellStartup' => 'UefiShellStartup',
+        'UefiShellStartupLocation' => 'UefiShellStartupLocation',
+        'UefiShellStartupUrl' => 'UefiShellStartupUrl'
+      )
     end
   end
 
   describe '#revert_bios' do
     it 'makes a PATCH rest call' do
       new_action = { 'BaseConfig' => 'default' }
-      expect(@client).to receive(:rest_patch).with('/redfish/v1/systems/1/bios/Settings/', body: new_action).and_return(FakeResponse.new)
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: new_action).and_return(FakeResponse.new)
       ret_val = @client.revert_bios
       expect(ret_val).to eq(true)
     end
   end
 
-  describe '#get_uefi_shell_startup' do
-    it 'makes a GET rest call' do
-      body = {
-        'UefiShellStartup' => 'UefiShellStartup',
-        'UefiShellStartupLocation' => 'UefiShellStartupLocation',
-        'UefiShellStartupUrl' => 'UefiShellStartupUrl'
-      }
-      fake_response = FakeResponse.new(body)
-      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
-      uefi_shell_startup = @client.get_uefi_shell_startup
-      expect(uefi_shell_startup).to eq(
-        'UefiShellStartup' => 'UefiShellStartup',
-        'UefiShellStartupLocation' => 'UefiShellStartupLocation',
-        'UefiShellStartupUrl' => 'UefiShellStartupUrl'
-      )
-    end
-  end
-
-  describe '#set_uefi_shell_startup' do
+  describe '#set_bios_settings' do
     it 'makes a PATCH rest call' do
-      new_action = {
-        'UefiShellStartup' => 'uefi_shell_startup',
-        'UefiShellStartupLocation' => 'uefi_shell_startup_location',
-        'UefiShellStartupUrl' => 'uefi_shell_startup_url'
-      }
-      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: new_action).and_return(FakeResponse.new)
-      ret_val = @client.set_uefi_shell_startup('uefi_shell_startup', 'uefi_shell_startup_location', 'uefi_shell_startup_url')
-      expect(ret_val).to eq(true)
-    end
-  end
-
-  describe '#get_bios_dhcp' do
-    it 'makes a GET rest call' do
-      body = {
-        'Dhcpv4' => 'Enabled',
-        'Ipv4Address' => '0.0.0.0',
-        'Ipv4Gateway' => '0.0.0.0',
-        'Ipv4PrimaryDNS' => '0.0.0.0',
-        'Ipv4SecondaryDNS' => '0.0.0.0',
-        'Ipv4SubnetMask' => '0.0.0.0'
-      }
-      fake_response = FakeResponse.new(body)
-      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
-      bios_dhcp = @client.get_bios_dhcp
-      expect(bios_dhcp).to eq(
-        'Dhcpv4' => 'Enabled',
-        'Ipv4Address' => '0.0.0.0',
-        'Ipv4Gateway' => '0.0.0.0',
-        'Ipv4PrimaryDNS' => '0.0.0.0',
-        'Ipv4SecondaryDNS' => '0.0.0.0',
-        'Ipv4SubnetMask' => '0.0.0.0'
-      )
-    end
-  end
-
-  describe '#set_bios_dhcp' do
-    it 'makes a PATCH rest call' do
-      new_action = {
-        'Dhcpv4' => 'Enabled',
-        'Ipv4Address' => '0.0.0.0',
-        'Ipv4Gateway' => '0.0.0.0',
-        'Ipv4PrimaryDNS' => '0.0.0.0',
-        'Ipv4SecondaryDNS' => '0.0.0.0',
-        'Ipv4SubnetMask' => '0.0.0.0'
-      }
-      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: new_action).and_return(FakeResponse.new)
-      ret_val = @client.set_bios_dhcp('Enabled', '0.0.0.0', '0.0.0.0', '0.0.0.0', '0.0.0.0', '0.0.0.0')
-      expect(ret_val).to eq(true)
-    end
-  end
-
-  describe '#get_url_boot_file' do
-    it 'makes a GET rest call' do
-      fake_response = FakeResponse.new('UrlBootFile' => 'http://wwww.urlbootfiletest.iso')
-      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
-      url_boot_file = @client.get_url_boot_file
-      expect(url_boot_file).to eq('http://wwww.urlbootfiletest.iso')
-    end
-  end
-
-  describe '#set_url_boot_file' do
-    it 'makes a PATCH rest call' do
-      new_action = { 'UrlBootFile' => 'http://wwww.urlbootfiletest.iso' }
-      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: new_action).and_return(FakeResponse.new)
-      ret_val = @client.set_url_boot_file('http://wwww.urlbootfiletest.iso')
-      expect(ret_val).to eq(true)
-    end
-  end
-
-  describe '#get_bios_service' do
-    it 'makes a GET rest call' do
-      body = {
+      bios_settings = {
         'ServiceName' => 'John Doe',
         'ServiceEmail' => 'john.doe@hpe.com'
       }
-      fake_response = FakeResponse.new(body)
-      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
-      bios_service = @client.get_bios_service
-      expect(bios_service).to eq(
-        'ServiceName' => 'John Doe',
-        'ServiceEmail' => 'john.doe@hpe.com'
-      )
-    end
-  end
-
-  describe '#set_bios_service' do
-    it 'makes a PATCH rest call' do
-      new_action = {
-        'ServiceName' => 'John Doe',
-        'ServiceEmail' => 'john.doe@hpe.com'
-      }
-      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: new_action).and_return(FakeResponse.new)
-      ret_val = @client.set_bios_service('John Doe', 'john.doe@hpe.com')
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: bios_settings).and_return(FakeResponse.new)
+      ret_val = @client.set_bios_settings(bios_settings)
       expect(ret_val).to eq(true)
     end
   end


### PR DESCRIPTION
New style of how to interact with API endpoints. Instead of specific methods for a set of attributes, user can specify exactly which ones they want to get and set.