### PR TITLE
BIOS and ComputerSystem updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ client.delete_user('user1')
 
 #### Bios
 ```ruby
+# Get all BIOS settings
+settings = client.get_bios_settings
+
+# Set BIOS settings
+client.set_bios_settings(
+  UefiShellStartup: 'Enabled',
+  Ipv4Gateway: '10.0.1.1',
+  ServiceEmail: 'admin@domain.com'
+  # Note that you can set many more options here. This is just an example.
+)
+
 # Get BIOS base configuration:
 baseconfig = client.get_bios_baseconfig
 
@@ -123,7 +134,7 @@ bios_service_settings = client.get_bios_service
 
 # Set BIOS service settings:
 service_name = 'my_name'
-service_email = 'my_name@hpe.com'
+service_email = 'my_name@domain.com'
 client.set_bios_service(service_name, service_email)
 ```
 
@@ -272,7 +283,7 @@ duration = 10 # hours
 logs = client.get_log(severity_level, duration, log_type)
 ```
 
-### Manager Account
+#### Manager Account
 ```ruby
 # Get the Account Privileges for a specific user:
 username = 'Administrator'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ruby SDK for HPE iLO
+
 [![Gem Version](https://badge.fury.io/rb/ilo-sdk.svg)](https://badge.fury.io/rb/ilo-sdk)
 
 Software Development Kit for interacting with the Hewlett Packard Enterprise iLO (Integrated Lights-Out) server management technology.
@@ -24,6 +25,7 @@ Software Development Kit for interacting with the Hewlett Packard Enterprise iLO
 
 
 ## Client
+
 Everything you do with this API happens through a client object.
 Creating the client object is the first step; then you can perform actions on the client.
 
@@ -56,6 +58,7 @@ export ILO_SSL_ENABLED=false # NOTE: Disabling SSL is strongly discouraged. Plea
 :lock: Tip: Be sure nobody can access to your environment variables
 
 ### Custom logging
+
 The default logger is a standard logger to STDOUT, but if you want to specify your own, you can.  However, your logger must implement the following methods:
 
 ```ruby
@@ -68,9 +71,11 @@ level=(Symbol, etc.) # The parameter here will be the log_level attribute
 
 
 ## Actions
+
 Actions are performed on the client, and defined in the [helper modules](lib/ilo-sdk/helpers).
 
 #### Account Service
+
 ```ruby
 # Get list of users:
 users = client.get_users
@@ -86,6 +91,7 @@ client.delete_user('user1')
 ```
 
 #### Bios
+
 ```ruby
 # Get all BIOS settings
 settings = client.get_bios_settings
@@ -95,7 +101,7 @@ client.set_bios_settings(
   UefiShellStartup: 'Enabled',
   Ipv4Gateway: '10.0.1.1',
   ServiceEmail: 'admin@domain.com'
-  # Note that you can set many more options here. This is just an example.
+  # Note: You can set many more options here. This is just an example.
 )
 
 # Get BIOS base configuration:
@@ -139,6 +145,7 @@ client.set_bios_service(service_name, service_email)
 ```
 
 #### Boot Settings
+
 ```ruby
 # Get boot order base configuration:
 baseconfig = client.get_boot_baseconfig
@@ -169,6 +176,7 @@ client.set_temporary_boot_order(boot_source_override_target)
 ```
 
 #### Chassis
+
 ```ruby
 # Get power metrics information:
 power_metrics = client.get_power_metrics
@@ -178,6 +186,7 @@ thermal_metrics = client.get_thermal_metrics
 ```
 
 #### Computer Details
+
 ```ruby
 # Get computer details (including general, network, and array controller details):
 computer_details = client.get_computer_details
@@ -193,21 +202,21 @@ array_controller_details = client.get_array_controller_details
 ```
 
 #### Computer System
+
 ```ruby
-# Get the computer system asset tag:
-asset_tag = client.get_asset_tag
+# Get computer system settings
+settings = client.get_system_settings
 
-# Set the computer system asset tag:
-client.set_asset_tag('HP001')
-
-# Get the indicator led state:
-indicator_led = client.get_indicator_led
-
-# Set the indicator led state:
-client.set_indicator_led('Lit')
+# Set computer system settings
+client.set_system_settings(
+  AssetTag: 'HP001',
+  IndicatorLED: 'Lit'
+  # Note: You can set more options here. This is just an example.
+)
 ```
 
 #### Date Time
+
 ```ruby
 # Get the time zone:
 time_zone = client.get_time_zone
@@ -230,6 +239,7 @@ client.set_ntp_server(ntp_servers)
 ```
 
 #### Firmware
+
 ```ruby
 # Get the firmware version:
 fw_version = client.get_fw_version
@@ -239,6 +249,7 @@ client.set_fw_upgrade('www.firmwareupgrade.com')
 ```
 
 #### HTTPS Certificate
+
 ```ruby
 # Get the current SSL Certificate and check to see if expires within 24 hours
 expiration = client.get_certificate.not_after.to_datetime
@@ -269,6 +280,7 @@ end
 ```
 
 #### Log Entry
+
 ```ruby
 # Clear a specific type of logs:
 log_type = 'IEL'
@@ -284,6 +296,7 @@ logs = client.get_log(severity_level, duration, log_type)
 ```
 
 #### Manager Account
+
 ```ruby
 # Get the Account Privileges for a specific user:
 username = 'Administrator'
@@ -305,6 +318,7 @@ client.set_account_privileges(username, privileges)
 ```
 
 #### Manager Network Protocol
+
 ```ruby
 # Get the minutes until session timeout:
 timeout = client.get_timeout
@@ -314,6 +328,7 @@ client.set_timeout(60)
 ```
 
 #### Power
+
 ```ruby
 # Get the power state of the system:
 power_state = client.get_power_state
@@ -326,6 +341,7 @@ client.reset_ilo
 ```
 
 #### Secure Boot
+
 ```ruby
 # Get whether or not UEFI secure boot is enabled:
 uefi_secure_boot = client.get_uefi_secure_boot
@@ -335,6 +351,7 @@ client.set_uefi_secure_boot(true)
 ```
 
 #### Service Root
+
 ```ruby
 # Get the schema information with a given prefix:
 schema_prefix = 'Account'
@@ -346,6 +363,7 @@ registry = client.get_registry(registry_prefix)
 ```
 
 #### SNMP
+
 ```ruby
 # Get the SNMP mode:
 snmp_mode = client.get_snmp_mode
@@ -360,6 +378,7 @@ client.set_snmp(snmp_mode, snmp_alerts_enabled)
 ```
 
 #### Virtual Media
+
 ```ruby
 # Get the virtual media information:
 virtual_media = client.get_virtual_media
@@ -377,6 +396,7 @@ client.eject_virtual_media(id)
 ```
 
 ## Custom requests
+
 In most cases, interacting with the client object is enough, but sometimes you need to make your own custom requests to the iLO.
 This project makes it extremely easy to do with some built-in methods for the client object. Here are some examples:
 
@@ -418,10 +438,12 @@ HINT: The @client object is available to you
 
 
 ## License
+
 This project is licensed under the Apache 2.0 license. Please see [LICENSE](LICENSE) for more info.
 
 
 ## Contributing and feature requests
+
 **Contributing:** You know the drill. Fork it, branch it, change it, commit it, and pull-request it.
 We are passionate about improving this project, and glad to accept help to make it better. However, keep the following in mind:
 
@@ -433,11 +455,13 @@ We are passionate about improving this project, and glad to accept help to make 
 This feedback is crucial for us to deliver a useful product. Do not assume we have already thought of everything, because we assure you that is not the case.
 
 ### Building the Gem
+
 First run `$ bundle` (requires the bundler gem), then...
  - To build only, run `$ rake build`.
  - To build and install the gem, run `$ rake install`.
 
 ### Testing
+
  - RuboCop: `$ rake rubocop`
  - Unit: `$ rake spec`
  - All test: `$ rake test`
@@ -445,6 +469,7 @@ First run `$ bundle` (requires the bundler gem), then...
 Note: run `$ rake -T` to get a list of all the available rake tasks.
 
 ## Authors
+
  - Anirudh Gupta - [@Anirudh-Gupta](https://github.com/Anirudh-Gupta)
  - Bik Bajwa - [@bikbajwa](https://github.com/bikbajwa)
  - Jared Smartt - [@jsmartt](https://github.com/jsmartt)

--- a/lib/ilo-sdk/helpers/bios_helper.rb
+++ b/lib/ilo-sdk/helpers/bios_helper.rb
@@ -13,6 +13,7 @@ module ILO_SDK
   # Contains helper methods for Bios actions
   module BiosHelper
     # Get all the BIOS settings
+    # @param system_id [Integer, String] ID of the system
     # @raise [RuntimeError] if the request failed
     # @return [Hash] BIOS settings
     def get_bios_settings(system_id = 1)

--- a/lib/ilo-sdk/helpers/bios_helper.rb
+++ b/lib/ilo-sdk/helpers/bios_helper.rb
@@ -12,6 +12,24 @@
 module ILO_SDK
   # Contains helper methods for Bios actions
   module BiosHelper
+    # Get all the BIOS settings
+    # @raise [RuntimeError] if the request failed
+    # @return [Hash] BIOS settings
+    def get_bios_settings(system_id = 1)
+      response_handler(rest_get("/redfish/v1/Systems/#{system_id}/bios/Settings/"))
+    end
+
+    # Set BIOS settings
+    # @param options [Hash] Hash of options to set
+    # @param system_id [Integer, String] ID of the system
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_bios_settings(options, system_id = 1)
+      r = response_handler(rest_patch("/redfish/v1/Systems/#{system_id}/bios/Settings/", body: options))
+      @logger.warn(r) if r['error']
+      true
+    end
+
     # Get the bios base config
     # @raise [RuntimeError] if the request failed
     # @return [Fixnum] bios_baseconfig
@@ -44,9 +62,9 @@ module ILO_SDK
     end
 
     # Set the UEFI shell start up
-    # @param [String, Symbol] uefi_shell_startup
-    # @param [String, Symbol] uefi_shell_startup_location
-    # @param [String, Symbol] uefi_shell_startup_url
+    # @param uefi_shell_startup [String, Symbol]
+    # @param uefi_shell_startup_location [String, Symbol]
+    # @param uefi_shell_startup_url [String, Symbol]
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_uefi_shell_startup(uefi_shell_startup, uefi_shell_startup_location, uefi_shell_startup_url)
@@ -77,12 +95,12 @@ module ILO_SDK
     end
 
     # Set the BIOS DHCP
-    # @param [String, Symbol] dhcpv4
-    # @param [String, Symbol] ipv4_address
-    # @param [String, Symbol] ipv4_gateway
-    # @param [String, Symbol] ipv4_primary_dns
-    # @param [String, Symbol] ipv4_secondary_dns
-    # @param [String, Symbol] ipv4_subnet_mask
+    # @param dhcpv4 [String, Symbol]
+    # @param ipv4_address [String, Symbol]
+    # @param ipv4_gateway [String, Symbol]
+    # @param ipv4_primary_dns [String, Symbol]
+    # @param ipv4_secondary_dns [String, Symbol]
+    # @param ipv4_subnet_mask [String, Symbol]
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_bios_dhcp(dhcpv4, ipv4_address = '', ipv4_gateway = '', ipv4_primary_dns = '', ipv4_secondary_dns = '', ipv4_subnet_mask = '')
@@ -108,7 +126,7 @@ module ILO_SDK
     end
 
     # Set the URL boot file
-    # @param [String, Symbol] url_boot_file
+    # @param url_boot_file [String, Symbol]
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_url_boot_file(url_boot_file)
@@ -131,8 +149,8 @@ module ILO_SDK
     end
 
     # Set the BIOS service
-    # @param [String, Symbol] name
-    # @param [String, Symbol] email
+    # @param name [String, Symbol]
+    # @param email [String, Symbol]
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_bios_service(name, email)

--- a/lib/ilo-sdk/helpers/computer_system_helper.rb
+++ b/lib/ilo-sdk/helpers/computer_system_helper.rb
@@ -1,7 +1,7 @@
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed
@@ -12,19 +12,41 @@
 module ILO_SDK
   # Contains helper methods for Computer System actions
   module ComputerSystemHelper
+    # Get the computer system settings
+    # @param system_id [Integer, String] ID of the system
+    # @raise [RuntimeError] if the request failed
+    # @return [Hash] Computer system settings
+    def get_system_settings(system_id = 1)
+      response_handler(rest_get("/redfish/v1/Systems/#{system_id}/"))
+    end
+
+    # Set computer system settings
+    # @param options [Hash] Hash of options to set
+    # @param system_id [Integer, String] ID of the system
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_system_settings(options, system_id = 1)
+      response_handler(rest_patch("/redfish/v1/Systems/#{system_id}/", body: options))
+      true
+    end
+
     # Get the Asset Tag
+    # @deprecated Use {#get_system_settings} instead
     # @raise [RuntimeError] if the request failed
     # @return [String] asset_tag
     def get_asset_tag
+      @logger.warn '[Deprecated] `get_asset_tag` is deprecated. Please use `get_system_settings[\'AssetTag\']` instead.'
       response = rest_get('/redfish/v1/Systems/1/')
       response_handler(response)['AssetTag']
     end
 
     # Set the Asset Tag
-    # @param [String, Symbol] asset_tag
+    # @deprecated Use {#set_system_settings} instead
+    # @param asset_tag [String, Symbol]
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_asset_tag(asset_tag)
+      @logger.warn '[Deprecated] `set_asset_tag` is deprecated. Please use `set_system_settings(AssetTag: <tag>)` instead.'
       new_action = { 'AssetTag' => asset_tag }
       response = rest_patch('/redfish/v1/Systems/1/', body: new_action)
       response_handler(response)
@@ -32,18 +54,22 @@ module ILO_SDK
     end
 
     # Get the UID indicator LED state
+    # @deprecated Use {#get_system_settings} instead
     # @raise [RuntimeError] if the request failed
     # @return [String] indicator_led
     def get_indicator_led
+      @logger.warn '[Deprecated] `get_indicator_led` is deprecated. Please use `get_system_settings[\'IndicatorLED\']` instead.'
       response = rest_get('/redfish/v1/Systems/1/')
       response_handler(response)['IndicatorLED']
     end
 
     # Set the UID indicator LED
-    # @param [String, Symbol] state
+    # @deprecated Use {#set_system_settings} instead
+    # @param state [String, Symbol]
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_indicator_led(state)
+      @logger.warn '[Deprecated] `set_indicator_led` is deprecated. Please use `set_system_settings(IndicatorLED: <state>)` instead.'
       new_action = { 'IndicatorLED' => state }
       response = rest_patch('/redfish/v1/Systems/1/', body: new_action)
       response_handler(response)

--- a/lib/ilo-sdk/version.rb
+++ b/lib/ilo-sdk/version.rb
@@ -1,7 +1,7 @@
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software distributed
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module ILO_SDK
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/unit/helpers/bios_spec.rb
+++ b/spec/unit/helpers/bios_spec.rb
@@ -3,6 +3,43 @@ require_relative './../../spec_helper'
 RSpec.describe ILO_SDK::Client do
   include_context 'shared context'
 
+  let(:settings) do
+    { 'key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3' }
+  end
+
+  describe '#get_bios_settings' do
+    it 'makes a GET rest call' do
+      fake_response = FakeResponse.new(settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/bios/Settings/').and_return(fake_response)
+      expect(@client.get_bios_settings).to eq(settings)
+    end
+
+    it 'allows the system_id to be set' do
+      fake_response = FakeResponse.new(settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/3/bios/Settings/').and_return(fake_response)
+      expect(@client.get_bios_settings(3)).to eq(settings)
+    end
+  end
+
+  describe '#set_bios_settings' do
+    it 'makes a PATCH rest call' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: settings).and_return(FakeResponse.new)
+      expect(@client.set_bios_settings(settings)).to eq(true)
+    end
+
+    it 'allows the system_id to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/3/bios/Settings/', body: settings).and_return(FakeResponse.new)
+      @client.set_bios_settings(settings, 3)
+    end
+
+    it 'prints a warning if one is returned' do
+      fake_response = FakeResponse.new('error' => 'Message')
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/bios/Settings/', body: settings).and_return(fake_response)
+      expect(@client.logger).to receive(:warn).with('error' => 'Message').and_return true
+      @client.set_bios_settings(settings)
+    end
+  end
+
   describe '#get_bios_baseconfig' do
     it 'makes a GET rest call' do
       fake_response = FakeResponse.new('BaseConfig' => 'default')

--- a/spec/unit/helpers/computer_system_spec.rb
+++ b/spec/unit/helpers/computer_system_spec.rb
@@ -3,8 +3,39 @@ require_relative './../../spec_helper'
 RSpec.describe ILO_SDK::Client do
   include_context 'shared context'
 
+  let(:settings) do
+    { 'key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3' }
+  end
+
+  describe '#get_system_settings' do
+    it 'makes a GET rest call' do
+      fake_response = FakeResponse.new(settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/').and_return(fake_response)
+      expect(@client.get_system_settings).to eq(settings)
+    end
+
+    it 'allows the system_id to be set' do
+      fake_response = FakeResponse.new(settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/3/').and_return(fake_response)
+      expect(@client.get_system_settings(3)).to eq(settings)
+    end
+  end
+
+  describe '#set_system_settings' do
+    it 'makes a PATCH rest call' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/', body: settings).and_return(FakeResponse.new)
+      expect(@client.set_system_settings(settings)).to eq(true)
+    end
+
+    it 'allows the system_id to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/3/', body: settings).and_return(FakeResponse.new)
+      @client.set_system_settings(settings, 3)
+    end
+  end
+
   describe '#get_asset_tag' do
     it 'makes a GET rest call' do
+      expect(@client.logger).to receive(:warn).with(/Deprecated/).and_return(true)
       fake_response = FakeResponse.new('AssetTag' => 'HP001')
       expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/').and_return(fake_response)
       state = @client.get_asset_tag
@@ -14,6 +45,7 @@ RSpec.describe ILO_SDK::Client do
 
   describe '#set_asset_tag' do
     it 'makes a PATCH rest call' do
+      expect(@client.logger).to receive(:warn).with(/Deprecated/).and_return(true)
       options = { 'AssetTag' => 'HP002' }
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/', body: options).and_return(FakeResponse.new)
       ret_val = @client.set_asset_tag('HP002')
@@ -23,6 +55,7 @@ RSpec.describe ILO_SDK::Client do
 
   describe '#get_indicator_led' do
     it 'makes a GET rest call' do
+      expect(@client.logger).to receive(:warn).with(/Deprecated/).and_return(true)
       fake_response = FakeResponse.new('IndicatorLED' => 'Off')
       expect(@client).to receive(:rest_get).with('/redfish/v1/Systems/1/').and_return(fake_response)
       state = @client.get_indicator_led
@@ -32,6 +65,7 @@ RSpec.describe ILO_SDK::Client do
 
   describe '#set_indicator_led' do
     it 'makes a PATCH rest call' do
+      expect(@client.logger).to receive(:warn).with(/Deprecated/).and_return(true)
       options = { 'IndicatorLED' => :Lit }
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Systems/1/', body: options).and_return(FakeResponse.new)
       ret_val = @client.set_indicator_led(:Lit)


### PR DESCRIPTION
This makes a few documentation updates, but mainly, it updates the bios and computer_system helpers with more generic getter and setter methods. Instead of having individual methods to get/set individual attributes on the same endpoint, this allows you to use the same method to set them (all at once if you'd like).

Honestly, many more methods need this same sort of refactor, but this is a start.

Note: This doesn't break old functionality, but adds a deprecation warning.