### PR TITLE
Added rest command to cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### New (Unreleased)
 
+#### v1.2.1
+ - Added rest command to cli
+
 ### v1.2.0
  - Added custom exception classes
  - Added disable_proxy client option

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ client.eject_virtual_media(id)
 
 ## Custom requests
 
-In most cases, interacting with the client object is enough, but sometimes you need to make your own custom requests to the iLO.
+This gem includes some usefull helper methods, but sometimes you need to make your own custom requests to the iLO.
 This project makes it extremely easy to do with some built-in methods for the client object. Here are some examples:
 
 ```ruby
@@ -408,10 +408,18 @@ response = client.rest_get('/rest/v1/Schemas')
 
 # Then we can validate the response and convert the response body into a hash...
 data = client.response_handler(response)
+
+# For updating iLO resources, use patch:
+options = { ServiceName: 'iLO Admin', ServiceEmail: 'admin@domain.com' }
+response = rest_patch('/redfish/v1/Systems/1/bios/Settings/', body: options)
+
+# For creating new iLO resources, use post:
+options = { UserName: 'admin', Password: '123' }
+response = rest_post('/redfish/v1/AccountService/Accounts/', body: options)
 ```
 
-This example is about as basic as it gets, but you can make any type of iLO request.
-If a resource does not do what you need, this will allow you to do it.
+These example are about as basic as it gets, but you can make any type of iLO API request.
+If a helper does not do what you need, this will allow you to do it.
 Please refer to the documentation and [code](lib/ilo-sdk/rest.rb) for complete list of methods and information about how to use them.
 
 

--- a/lib/ilo-sdk/rest.rb
+++ b/lib/ilo-sdk/rest.rb
@@ -151,7 +151,7 @@ module ILO_SDK
       when 'delete', :delete
         request = Net::HTTP::Delete.new(uri.request_uri)
       else
-        raise InvalidRequest, "Invalid rest call: #{type}"
+        raise InvalidRequest, "Invalid rest method: #{type}. Valid methods are: get, post, put, patch, delete"
       end
       options['Content-Type'] ||= 'application/json'
       options.delete('Content-Type') if [:none, 'none', nil].include?(options['Content-Type'])

--- a/lib/ilo-sdk/version.rb
+++ b/lib/ilo-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module ILO_SDK
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ SimpleCov.start do
   add_filter 'spec/'
   add_group 'Client', client_files
   add_group 'Helpers', helper_path
-  minimum_coverage 89 # TODO: bump up as we increase coverage. Goal: 95%
+  minimum_coverage 90 # TODO: bump up as we increase coverage. Goal: 95%
   minimum_coverage_by_file 10 # TODO: bump up as we increase coverage. Goal: 90%
 end
 

--- a/spec/unit/cli/login_spec.rb
+++ b/spec/unit/cli/login_spec.rb
@@ -6,10 +6,17 @@ RSpec.describe ILO_SDK::Cli do
   describe '#login' do
     let(:command) { ILO_SDK::Cli.start(['login']) }
 
-    it 'prints the token' do
+    it 'prints a success message' do
       expect_any_instance_of(ILO_SDK::Client).to receive(:rest_get).with('/redfish/v1/Sessions/')
         .and_return(FakeResponse.new)
       expect { command }.to output(/Login Successful!/).to_stdout_from_any_process
+    end
+
+    it 'errors out if the login fails' do
+      expect_any_instance_of(ILO_SDK::Client).to receive(:rest_get).with('/redfish/v1/Sessions/')
+        .and_return(FakeResponse.new({}, 401))
+      expect($stderr).to receive(:puts).with(/Unauthorized/i)
+      expect { command }.to raise_error SystemExit
     end
   end
 end

--- a/spec/unit/cli/rest_spec.rb
+++ b/spec/unit/cli/rest_spec.rb
@@ -1,0 +1,89 @@
+require_relative './../../spec_helper'
+
+RSpec.describe ILO_SDK::Cli do
+  include_context 'cli context'
+
+  let(:response) { { 'key1' => 'val1', 'key2' => 'val2', 'key3' => { 'key4' => 'val4' } } }
+
+  describe '#rest get' do
+    it 'requires a URI' do
+      expect($stderr).to receive(:puts).with(/ERROR.*arguments/)
+      ILO_SDK::Cli.start(%w(rest get))
+    end
+
+    it 'sends any data that is passed in' do
+      data = { 'ServiceName' => 'iLO Admin', 'ServiceEmail' => 'admin@domain.com' }
+      expect_any_instance_of(ILO_SDK::Client).to receive(:rest_api)
+        .with('get', '/redfish/v1/', body: data).and_return FakeResponse.new(response)
+      expect { ILO_SDK::Cli.start(['rest', 'get', 'redfish/v1/', '-d', data.to_json]) }
+        .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+    end
+
+    context 'output formats' do
+      before :each do
+        expect_any_instance_of(ILO_SDK::Client).to receive(:rest_api)
+          .with('get', '/redfish/v1/', {}).and_return FakeResponse.new(response)
+      end
+
+      it 'makes a GET call to the URI and outputs the response in json format' do
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1/)) }
+          .to output(JSON.pretty_generate(response) + "\n").to_stdout_from_any_process
+      end
+
+      it 'can output the response in raw format' do
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1/ -f raw)) }
+          .to output(response.to_json + "\n").to_stdout_from_any_process
+      end
+
+      it 'can output the response in yaml format' do
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1/ -f yaml)) }
+          .to output(response.to_yaml).to_stdout_from_any_process
+      end
+    end
+
+    context 'bad requests' do
+      it 'fails if the data cannot be parsed as json' do
+        expect($stderr).to receive(:puts).with(/Failed to parse data as JSON/)
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1/ -d fake_json)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the request method is invalid' do
+        expect($stderr).to receive(:puts).with(/Invalid rest method/)
+        expect { ILO_SDK::Cli.start(%w(rest blah redfish/v1/)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the response code is 3XX' do
+        headers = { 'location' => ['redfish/v1/Systems/1/'] }
+        body = {}
+        expect_any_instance_of(ILO_SDK::Client).to receive(:rest_api)
+          .with('get', '/redfish/v1', {}).and_return FakeResponse.new(body, 308, headers)
+        expect($stderr).to receive(:puts).with(/308.*location/m)
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the response code is 4XX' do
+        headers = { 'content-type' => ['text/plain'] }
+        body = { 'Message' => 'Not found!' }
+        expect_any_instance_of(ILO_SDK::Client).to receive(:rest_api)
+          .with('get', '/redfish/v1', {}).and_return FakeResponse.new(body, 404, headers)
+        expect($stderr).to receive(:puts).with(/404.*content-type.*Not found/m)
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1)) }
+          .to raise_error SystemExit
+      end
+
+      it 'fails if the response code is 4XX' do
+        headers = { 'content-type' => ['text/plain'] }
+        body = { 'Message' => 'Server error!' }
+        expect_any_instance_of(ILO_SDK::Client).to receive(:rest_api)
+          .with('get', '/redfish/v1', {}).and_return FakeResponse.new(body, 500, headers)
+        expect($stderr).to receive(:puts).with(/500.*content-type.*Server error/m)
+        expect { ILO_SDK::Cli.start(%w(rest get redfish/v1)) }
+          .to raise_error SystemExit
+      end
+    end
+
+  end
+end

--- a/spec/unit/rest_spec.rb
+++ b/spec/unit/rest_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe ILO_SDK::Client do
     end
 
     it 'fails when an invalid request type is given' do
-      expect { @client.send(:build_request, :fake, @uri, {}) }.to raise_error(/Invalid rest call/)
+      expect { @client.send(:build_request, :fake, @uri, {}) }.to raise_error(/Invalid rest method/)
     end
 
     context 'default header values' do


### PR DESCRIPTION
Adds a rest command to the cli. Makes it super easy to make rest calls without needing to set curl auth headers or figure out how to pass in the data correctly. This also allows you to format the output into readable json, raw, or yaml.