### PR TITLE
Manager/EthernetInterface settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 # See default at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+AllCops:
+  TargetRubyVersion: 2.1
 
 Metrics/ClassLength:
   Max: 200

--- a/README.md
+++ b/README.md
@@ -249,13 +249,13 @@ client.get_ilo_ethernet_interface
 client.set_ilo_ipv4_dhcp
 
 # Set static IPv4 address, netmask and gateway
-client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '192.168.1.254')
+client.set_ilo_ipv4_static(ip: '192.168.1.1', netmask: '255.255.255.0', gateway: '192.168.1.254')
 
 # Set IPv4 DNS servers
-client.set_ilo_ipv4_dns_servers(['2.2.2.2', '4.4.4.4', '8.8.8.8'])
+client.set_ilo_ipv4_dns_servers(dns_servers: ['2.2.2.2', '4.4.4.4', '8.8.8.8'])
 
-# Set hostname and domain name
-client.set_ilo_hostname('server-ilo', 'domain.local') # => server-ilo.domain.local
+# Set hostname and domain name 'server-ilo.domain.local'
+client.set_ilo_hostname(hostname: 'server-ilo', domain_name: 'domain.local')
 ```
 
 #### Firmware

--- a/README.md
+++ b/README.md
@@ -239,6 +239,25 @@ ntp_servers = ['10.1.1.1', '10.1.1.2']
 client.set_ntp_server(ntp_servers)
 ```
 
+#### Manager EthernetInterface settings
+
+```ruby
+# Get EthernetInteface settings
+client.get_ilo_ethernet_interface
+
+# Set EthernetInterface to obtain all IPv4 parameters from DHCP server
+client.set_ilo_ipv4_dhcp
+
+# Set static IPv4 address, netmask and gateway
+client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '192.168.1.254')
+
+# Set IPv4 DNS servers
+client.set_ilo_ipv4_dns_servers(['2.2.2.2', '4.4.4.4', '8.8.8.8'])
+
+# Set hostname and domain name
+client.set_ilo_hostname('server-ilo', 'domain.local') # => server-ilo.domain.local
+```
+
 #### Firmware
 
 ```ruby

--- a/lib/ilo-sdk/client.rb
+++ b/lib/ilo-sdk/client.rb
@@ -81,5 +81,6 @@ module ILO_SDK
     include ChassisHelper
     include ServiceRootHelper
     include HttpsCertHelper
+    include EthernetInterfaceHelper
   end
 end

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -1,0 +1,77 @@
+# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module ILO_SDK
+  # Contains helper methods for EthernetInterface actions
+  module EthernetInterfaceHelper
+    # Get all the Ethernet Interface settings
+    # @param manager_id [Integer, String] ID of the Manager
+    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @raise [RuntimeError] if the request failed
+    # @return [Hash] EthernetInterface settings
+    def get_ilo_ethernet_interface(manager_id = 1, ethernet_interface = 1)
+      response_handler(rest_get("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}"))
+    end
+
+    # Set EthernetInterface to obtain IPv4 address from DHCP
+    # @param manager_id [Integer, String] ID of the Manager
+    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_ilo_dhcp(manager_id = 1, ethernet_interface = 1)
+      new_action = { 'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => true } } } }
+      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response_handler(response)
+      true
+    end
+
+    # Set EthernetInterface to static IPv4 address
+    # @paramm ip [String] IPv4 address
+    # @param netmask [String] IPv4 subnet mask
+    # @param gateway [String] IPv4 default gateway
+    # @param manager_id [Integer, String] ID of the Manager
+    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_ilo_static(ip, netmask, gateway='0.0.0.0', manager_id = 1, ethernet_interface = 1)
+      new_action = { 
+        'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => false } } }, 
+        'IPv4Addresses' => [
+          'Address' => ip, 'SubnetMask' => netmask, 'Gateway' => gateway
+        ]
+      }
+      puts new_action
+      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response_handler(response)
+      true
+    end
+    
+    # Set EthernetInterface DNS servers
+    # @paramm dns_servers [Array] list of DNS servers
+    # @param manager_id [Integer, String] ID of the Manager
+    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_ilo_dns_servers(dns_servers, manager_id = 1, ethernet_interface = 1)
+      new_action = {
+        'Oem' => { 
+          'Hp' => { 
+            'DHCPv4' => { 'UseDNSServers' => false },
+            'IPv4' => { 'DNSServers' => dns_servers }
+          }
+        }
+      }
+      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response_handler(response)
+      true
+    end
+  end
+end

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -62,7 +62,6 @@ module ILO_SDK
           'Address' => ip, 'SubnetMask' => netmask, 'Gateway' => gateway
         ]
       }
-      puts new_action
       response = rest_patch("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/", body: new_action)
       response_handler(response)
       true

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -14,19 +14,19 @@ module ILO_SDK
   module EthernetInterfaceHelper
     # Get all the Ethernet Interface settings
     # @param manager_id [Integer, String] ID of the Manager
-    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @param ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return [Hash] EthernetInterface settings
-    def get_ilo_ethernet_interface(manager_id = 1, ethernet_interface = 1)
+    def get_ilo_ethernet_interface(manager_id: 1, ethernet_interface: 1)
       response_handler(rest_get("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/"))
     end
 
     # Set EthernetInterface to obtain IPv4 settings from DHCP
     # @param manager_id [Integer, String] ID of the Manager
-    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @param ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_ipv4_dhcp(manager_id = 1, ethernet_interface = 1)
+    def set_ilo_ipv4_dhcp(manager_id: 1, ethernet_interface: 1)
       new_action = {
         'Oem' => {
           'Hp' => {
@@ -48,14 +48,14 @@ module ILO_SDK
     end
 
     # Set EthernetInterface to static IPv4 address
-    # @paramm ip [String] IPv4 address
+    # @param ip [String] IPv4 address
     # @param netmask [String] IPv4 subnet mask
     # @param gateway [String] IPv4 default gateway
     # @param manager_id [Integer, String] ID of the Manager
-    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @param ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_ipv4_static(ip, netmask, gateway = '0.0.0.0', manager_id = 1, ethernet_interface = 1)
+    def set_ilo_ipv4_static(ip:, netmask:, gateway: '0.0.0.0', manager_id: 1, ethernet_interface: 1)
       new_action = {
         'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => false } } },
         'IPv4Addresses' => [
@@ -68,12 +68,12 @@ module ILO_SDK
     end
 
     # Set EthernetInterface DNS servers
-    # @paramm dns_servers [Array] list of DNS servers
+    # @param dns_servers [Array] list of DNS servers
     # @param manager_id [Integer, String] ID of the Manager
-    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @param ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_ipv4_dns_servers(dns_servers, manager_id = 1, ethernet_interface = 1)
+    def set_ilo_ipv4_dns_servers(dns_servers:, manager_id: 1, ethernet_interface: 1)
       new_action = {
         'Oem' => {
           'Hp' => {
@@ -91,10 +91,10 @@ module ILO_SDK
     # @param hostname [String] iLO hostname
     # @param domain_name [String] iLO domain name
     # @param manager_id [Integer, String] ID of the Manager
-    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @param ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_hostname(hostname, domain_name = nil, manager_id = 1, ethernet_interface = 1)
+    def set_ilo_hostname(hostname:, domain_name: nil, manager_id: 1, ethernet_interface: 1)
       new_action = { 'Oem' => { 'Hp' => { 'HostName' => hostname } } }
       new_action['Oem']['Hp'].merge!('DHCPv4' => {}, 'DHCPv6' => {}) if domain_name
       new_action['Oem']['Hp']['DHCPv4']['UseDomainName'] = false if domain_name

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -18,7 +18,7 @@ module ILO_SDK
     # @raise [RuntimeError] if the request failed
     # @return [Hash] EthernetInterface settings
     def get_ilo_ethernet_interface(manager_id = 1, ethernet_interface = 1)
-      response_handler(rest_get("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}"))
+      response_handler(rest_get("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/"))
     end
 
     # Set EthernetInterface to obtain IPv4 settings from DHCP
@@ -26,7 +26,7 @@ module ILO_SDK
     # @ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_dhcp(manager_id = 1, ethernet_interface = 1)
+    def set_ilo_ipv4_dhcp(manager_id = 1, ethernet_interface = 1)
       new_action = {
         'Oem' => {
           'Hp' => {
@@ -42,7 +42,7 @@ module ILO_SDK
           }
         }
       }
-      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response = rest_patch("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/", body: new_action)
       response_handler(response)
       true
     end
@@ -55,7 +55,7 @@ module ILO_SDK
     # @ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_static(ip, netmask, gateway = '0.0.0.0', manager_id = 1, ethernet_interface = 1)
+    def set_ilo_ipv4_static(ip, netmask, gateway = '0.0.0.0', manager_id = 1, ethernet_interface = 1)
       new_action = {
         'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => false } } },
         'IPv4Addresses' => [
@@ -63,7 +63,7 @@ module ILO_SDK
         ]
       }
       puts new_action
-      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response = rest_patch("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/", body: new_action)
       response_handler(response)
       true
     end
@@ -74,7 +74,7 @@ module ILO_SDK
     # @ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_dns_servers(dns_servers, manager_id = 1, ethernet_interface = 1)
+    def set_ilo_ipv4_dns_servers(dns_servers, manager_id = 1, ethernet_interface = 1)
       new_action = {
         'Oem' => {
           'Hp' => {
@@ -83,7 +83,7 @@ module ILO_SDK
           }
         }
       }
-      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response = rest_patch("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/", body: new_action)
       response_handler(response)
       true
     end
@@ -99,7 +99,7 @@ module ILO_SDK
       new_action = { 'Oem' => { 'Hp' => { 'HostName' => hostname, 'DHCPv4' => {} } } }
       new_action['Oem']['Hp']['DHCPv4']['UseDomainName'] = false if domain_name
       new_action['Oem']['Hp']['DomainName'] = domain_name if domain_name
-      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response = rest_patch("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/", body: new_action)
       response_handler(response)
       true
     end

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -21,16 +21,16 @@ module ILO_SDK
       response_handler(rest_get("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}"))
     end
 
-    # Set EthernetInterface to obtain IPv4 address from DHCP
+    # Set EthernetInterface to obtain IPv4 settings from DHCP
     # @param manager_id [Integer, String] ID of the Manager
     # @ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_ilo_dhcp(manager_id = 1, ethernet_interface = 1)
-      new_action = { 
-        'Oem' => { 
-          'Hp' => { 
-            'DHCPv4' => { 
+      new_action = {
+        'Oem' => {
+          'Hp' => {
+            'DHCPv4' => {
               'Enabled' => true,
               'UseDNSServers' => true,
               'UseDomainName' => true,
@@ -38,9 +38,9 @@ module ILO_SDK
               'UseNTPServers' => true,
               'UseStaticRoutes' => true,
               'UseWINSServers' => true
-            } 
-          } 
-        } 
+            }
+          }
+        }
       }
       response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
       response_handler(response)
@@ -55,9 +55,9 @@ module ILO_SDK
     # @ethernet_interface [Integer, String] ID of the EthernetInterface
     # @raise [RuntimeError] if the request failed
     # @return true
-    def set_ilo_static(ip, netmask, gateway='0.0.0.0', manager_id = 1, ethernet_interface = 1)
-      new_action = { 
-        'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => false } } }, 
+    def set_ilo_static(ip, netmask, gateway = '0.0.0.0', manager_id = 1, ethernet_interface = 1)
+      new_action = {
+        'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => false } } },
         'IPv4Addresses' => [
           'Address' => ip, 'SubnetMask' => netmask, 'Gateway' => gateway
         ]
@@ -67,7 +67,7 @@ module ILO_SDK
       response_handler(response)
       true
     end
-    
+
     # Set EthernetInterface DNS servers
     # @paramm dns_servers [Array] list of DNS servers
     # @param manager_id [Integer, String] ID of the Manager
@@ -76,13 +76,29 @@ module ILO_SDK
     # @return true
     def set_ilo_dns_servers(dns_servers, manager_id = 1, ethernet_interface = 1)
       new_action = {
-        'Oem' => { 
-          'Hp' => { 
+        'Oem' => {
+          'Hp' => {
             'DHCPv4' => { 'UseDNSServers' => false },
             'IPv4' => { 'DNSServers' => dns_servers }
           }
         }
       }
+      response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
+      response_handler(response)
+      true
+    end
+
+    # Set iLO hostname and domain name
+    # @param hostname [String] iLO hostname
+    # @param domain_name [String] iLO domain name
+    # @param manager_id [Integer, String] ID of the Manager
+    # @ethernet_interface [Integer, String] ID of the EthernetInterface
+    # @raise [RuntimeError] if the request failed
+    # @return true
+    def set_ilo_hostname(hostname, domain_name = nil, manager_id = 1, ethernet_interface = 1)
+      new_action = { 'Oem' => { 'Hp' => { 'HostName' => hostname, 'DHCPv4' => {} } } }
+      new_action['Oem']['Hp']['DHCPv4']['UseDomainName'] = false if domain_name
+      new_action['Oem']['Hp']['DomainName'] = domain_name if domain_name
       response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
       response_handler(response)
       true

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -95,8 +95,10 @@ module ILO_SDK
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_ilo_hostname(hostname, domain_name = nil, manager_id = 1, ethernet_interface = 1)
-      new_action = { 'Oem' => { 'Hp' => { 'HostName' => hostname, 'DHCPv4' => {} } } }
+      new_action = { 'Oem' => { 'Hp' => { 'HostName' => hostname } } }
+      new_action['Oem']['Hp'].merge!('DHCPv4' => {}, 'DHCPv6' => {}) if domain_name
       new_action['Oem']['Hp']['DHCPv4']['UseDomainName'] = false if domain_name
+      new_action['Oem']['Hp']['DHCPv6']['UseDomainName'] = false if domain_name
       new_action['Oem']['Hp']['DomainName'] = domain_name if domain_name
       response = rest_patch("/redfish/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}/", body: new_action)
       response_handler(response)

--- a/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
+++ b/lib/ilo-sdk/helpers/ethernet_interface_helper.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 module ILO_SDK
-  # Contains helper methods for EthernetInterface actions
+  # Contains helper methods for EthernetInterface IPv4 actions
   module EthernetInterfaceHelper
     # Get all the Ethernet Interface settings
     # @param manager_id [Integer, String] ID of the Manager
@@ -27,7 +27,21 @@ module ILO_SDK
     # @raise [RuntimeError] if the request failed
     # @return true
     def set_ilo_dhcp(manager_id = 1, ethernet_interface = 1)
-      new_action = { 'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => true } } } }
+      new_action = { 
+        'Oem' => { 
+          'Hp' => { 
+            'DHCPv4' => { 
+              'Enabled' => true,
+              'UseDNSServers' => true,
+              'UseDomainName' => true,
+              'UseGateway' => true,
+              'UseNTPServers' => true,
+              'UseStaticRoutes' => true,
+              'UseWINSServers' => true
+            } 
+          } 
+        } 
+      }
       response = rest_patch("/rest/v1/Managers/#{manager_id}/EthernetInterfaces/#{ethernet_interface}", body: new_action)
       response_handler(response)
       true

--- a/lib/ilo-sdk/version.rb
+++ b/lib/ilo-sdk/version.rb
@@ -11,5 +11,5 @@
 
 # Gem version defined here
 module ILO_SDK
-  VERSION = '1.2.2'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/spec/unit/helpers/ethernet_interface_helper_spec.rb
+++ b/spec/unit/helpers/ethernet_interface_helper_spec.rb
@@ -115,4 +115,33 @@ RSpec.describe ILO_SDK::Client do
       expect(@client.set_ilo_ipv4_dns_servers(@dns_servers, 2, 2)).to eq(true)
     end
   end
+
+  describe '#set_ilo_hostname' do
+    before(:all) do
+      @body = { 'Oem' => { 'Hp' => { 'HostName' => 'server-ilo', 'DHCPv4' => {} } } }
+    end
+
+    it 'makes a PATCH rest call' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_hostname('server-ilo')).to eq(true)
+    end
+
+    it 'allows domain_name to be set' do
+      body = Marshal.load(Marshal.dump(@body))
+      body['Oem']['Hp']['DHCPv4']['UseDomainName'] = false
+      body['Oem']['Hp']['DomainName'] = 'domain.local'
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_hostname('server-ilo', 'domain.local')).to eq(true)
+    end
+
+    it 'allows the system_id to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_hostname('server-ilo', nil, 2)).to eq(true)
+    end
+
+    it 'allows system_id and ethernet_interface to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_hostname('server-ilo', nil, 2, 2)).to eq(true)
+    end
+  end
 end

--- a/spec/unit/helpers/ethernet_interface_helper_spec.rb
+++ b/spec/unit/helpers/ethernet_interface_helper_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ILO_SDK::Client do
 
   describe '#set_ilo_hostname' do
     before(:all) do
-      @body = { 'Oem' => { 'Hp' => { 'HostName' => 'server-ilo', 'DHCPv4' => {} } } }
+      @body = { 'Oem' => { 'Hp' => { 'HostName' => 'server-ilo' } } }
     end
 
     it 'makes a PATCH rest call' do
@@ -128,7 +128,7 @@ RSpec.describe ILO_SDK::Client do
 
     it 'allows domain_name to be set' do
       body = Marshal.load(Marshal.dump(@body))
-      body['Oem']['Hp']['DHCPv4']['UseDomainName'] = false
+      body['Oem']['Hp'].merge!('DHCPv4' => { 'UseDomainName' => false }, 'DHCPv6' => { 'UseDomainName' => false })
       body['Oem']['Hp']['DomainName'] = 'domain.local'
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: body).and_return(FakeResponse.new)
       expect(@client.set_ilo_hostname('server-ilo', 'domain.local')).to eq(true)

--- a/spec/unit/helpers/ethernet_interface_helper_spec.rb
+++ b/spec/unit/helpers/ethernet_interface_helper_spec.rb
@@ -1,0 +1,65 @@
+require_relative './../../spec_helper'
+
+RSpec.describe ILO_SDK::Client do
+  include_context 'shared context'
+
+  describe '#get_ilo_ethernet_interface' do
+    before(:all) do
+      @settings = { 'key1' => 'val1', 'key2' => 'val2', 'key3' => 'val3' }
+    end
+
+    it 'makes a GET rest call' do
+      fake_response = FakeResponse.new(@settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Managers/1/EthernetInterfaces/1/').and_return(fake_response)
+      expect(@client.get_ilo_ethernet_interface).to eq(@settings)
+    end
+
+    it 'allows the system_id to be set' do
+      fake_response = FakeResponse.new(@settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Managers/2/EthernetInterfaces/1/').and_return(fake_response)
+      expect(@client.get_ilo_ethernet_interface(2)).to eq(@settings)
+    end
+
+    it 'allows system_id and ethernet_interface to be set' do
+      fake_response = FakeResponse.new(@settings)
+      expect(@client).to receive(:rest_get).with('/redfish/v1/Managers/2/EthernetInterfaces/2/').and_return(fake_response)
+      expect(@client.get_ilo_ethernet_interface(2, 2)).to eq(@settings)
+    end
+
+  end
+
+  describe '#set_ilo_dhcp' do
+    before(:all) do
+      @enable_dhcp_body = {
+        'Oem' => {
+          'Hp' => {
+            'DHCPv4' => {
+              'Enabled' => true,
+              'UseDNSServers' => true,
+              'UseDomainName' => true,
+              'UseGateway' => true,
+              'UseNTPServers' => true,
+              'UseStaticRoutes' => true,
+              'UseWINSServers' => true
+            }
+          }
+        }
+      }
+    end
+
+    it 'makes a PATCH rest call' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @enable_dhcp_body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_dhcp).to eq(true)
+    end
+
+    it 'allows the system_id to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @enable_dhcp_body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_dhcp(2)).to eq(true)
+    end
+
+    it 'allows system_id and ethernet_interface to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @enable_dhcp_body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_dhcp(2, 2)).to eq(true)
+    end
+  end
+end

--- a/spec/unit/helpers/ethernet_interface_helper_spec.rb
+++ b/spec/unit/helpers/ethernet_interface_helper_spec.rb
@@ -62,4 +62,57 @@ RSpec.describe ILO_SDK::Client do
       expect(@client.set_ilo_ipv4_dhcp(2, 2)).to eq(true)
     end
   end
+
+  describe '#set_ilo_ipv4_static' do
+    before(:all) do
+      @body = {
+        'Oem' => { 'Hp' => { 'DHCPv4' => { 'Enabled' => false } } },
+        'IPv4Addresses' => ['Address' => '192.168.1.1', 'SubnetMask' => '255.255.255.0', 'Gateway' => '0.0.0.0']
+      }
+    end
+
+    it 'makes a PATCH rest call' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0')).to eq(true)
+    end
+
+    it 'allows the gateway to be set' do
+      body = Marshal.load(Marshal.dump(@body))
+      body['IPv4Addresses'][0]['Gateway'] = '192.168.1.254'
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '192.168.1.254')).to eq(true)
+    end
+
+    it 'allows the system_id to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '0.0.0.0', 2)).to eq(true)
+    end
+
+    it 'allows system_id and ethernet_interface to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '0.0.0.0', 2, 2)).to eq(true)
+    end
+  end
+
+  describe '#set_ilo_ipv4_dns_servers' do
+    before(:all) do
+      @dns_servers = ['2.2.2.2', '4.4.4.4', '8.8.8.8']
+      @body = { 'Oem' => { 'Hp' => { 'DHCPv4' => { 'UseDNSServers' => false }, 'IPv4' => { 'DNSServers' => @dns_servers } } } }
+    end
+
+    it 'makes a PATCH rest call' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_dns_servers(@dns_servers)).to eq(true)
+    end
+
+    it 'allows the system_id to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_dns_servers(@dns_servers, 2)).to eq(true)
+    end
+
+    it 'allows system_id and ethernet_interface to be set' do
+      expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @body).and_return(FakeResponse.new)
+      expect(@client.set_ilo_ipv4_dns_servers(@dns_servers, 2, 2)).to eq(true)
+    end
+  end
 end

--- a/spec/unit/helpers/ethernet_interface_helper_spec.rb
+++ b/spec/unit/helpers/ethernet_interface_helper_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe ILO_SDK::Client do
     it 'allows the system_id to be set' do
       fake_response = FakeResponse.new(@settings)
       expect(@client).to receive(:rest_get).with('/redfish/v1/Managers/2/EthernetInterfaces/1/').and_return(fake_response)
-      expect(@client.get_ilo_ethernet_interface(2)).to eq(@settings)
+      expect(@client.get_ilo_ethernet_interface(manager_id: 2)).to eq(@settings)
     end
 
     it 'allows system_id and ethernet_interface to be set' do
       fake_response = FakeResponse.new(@settings)
       expect(@client).to receive(:rest_get).with('/redfish/v1/Managers/2/EthernetInterfaces/2/').and_return(fake_response)
-      expect(@client.get_ilo_ethernet_interface(2, 2)).to eq(@settings)
+      expect(@client.get_ilo_ethernet_interface(manager_id: 2, ethernet_interface: 2)).to eq(@settings)
     end
 
   end
@@ -54,12 +54,12 @@ RSpec.describe ILO_SDK::Client do
 
     it 'allows the system_id to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @enable_dhcp_body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_dhcp(2)).to eq(true)
+      expect(@client.set_ilo_ipv4_dhcp(manager_id: 2)).to eq(true)
     end
 
     it 'allows system_id and ethernet_interface to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @enable_dhcp_body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_dhcp(2, 2)).to eq(true)
+      expect(@client.set_ilo_ipv4_dhcp(manager_id: 2, ethernet_interface: 2)).to eq(true)
     end
   end
 
@@ -73,24 +73,24 @@ RSpec.describe ILO_SDK::Client do
 
     it 'makes a PATCH rest call' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0')).to eq(true)
+      expect(@client.set_ilo_ipv4_static(ip: '192.168.1.1', netmask: '255.255.255.0')).to eq(true)
     end
 
     it 'allows the gateway to be set' do
       body = Marshal.load(Marshal.dump(@body))
       body['IPv4Addresses'][0]['Gateway'] = '192.168.1.254'
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '192.168.1.254')).to eq(true)
+      expect(@client.set_ilo_ipv4_static(ip: '192.168.1.1', netmask: '255.255.255.0', gateway: '192.168.1.254')).to eq(true)
     end
 
     it 'allows the system_id to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '0.0.0.0', 2)).to eq(true)
+      expect(@client.set_ilo_ipv4_static(ip: '192.168.1.1', netmask: '255.255.255.0', manager_id: 2)).to eq(true)
     end
 
     it 'allows system_id and ethernet_interface to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_static('192.168.1.1', '255.255.255.0', '0.0.0.0', 2, 2)).to eq(true)
+      expect(@client.set_ilo_ipv4_static(ip: '192.168.1.1', netmask: '255.255.255.0', manager_id: 2, ethernet_interface: 2)).to eq(true)
     end
   end
 
@@ -102,17 +102,17 @@ RSpec.describe ILO_SDK::Client do
 
     it 'makes a PATCH rest call' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_dns_servers(@dns_servers)).to eq(true)
+      expect(@client.set_ilo_ipv4_dns_servers(dns_servers: @dns_servers)).to eq(true)
     end
 
     it 'allows the system_id to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_dns_servers(@dns_servers, 2)).to eq(true)
+      expect(@client.set_ilo_ipv4_dns_servers(dns_servers: @dns_servers, manager_id: 2)).to eq(true)
     end
 
     it 'allows system_id and ethernet_interface to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_ipv4_dns_servers(@dns_servers, 2, 2)).to eq(true)
+      expect(@client.set_ilo_ipv4_dns_servers(dns_servers: @dns_servers, manager_id: 2, ethernet_interface: 2)).to eq(true)
     end
   end
 
@@ -123,7 +123,7 @@ RSpec.describe ILO_SDK::Client do
 
     it 'makes a PATCH rest call' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_hostname('server-ilo')).to eq(true)
+      expect(@client.set_ilo_hostname(hostname: 'server-ilo')).to eq(true)
     end
 
     it 'allows domain_name to be set' do
@@ -131,17 +131,17 @@ RSpec.describe ILO_SDK::Client do
       body['Oem']['Hp'].merge!('DHCPv4' => { 'UseDomainName' => false }, 'DHCPv6' => { 'UseDomainName' => false })
       body['Oem']['Hp']['DomainName'] = 'domain.local'
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/1/EthernetInterfaces/1/', body: body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_hostname('server-ilo', 'domain.local')).to eq(true)
+      expect(@client.set_ilo_hostname(hostname: 'server-ilo', domain_name: 'domain.local')).to eq(true)
     end
 
     it 'allows the system_id to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/1/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_hostname('server-ilo', nil, 2)).to eq(true)
+      expect(@client.set_ilo_hostname(hostname: 'server-ilo', manager_id: 2)).to eq(true)
     end
 
     it 'allows system_id and ethernet_interface to be set' do
       expect(@client).to receive(:rest_patch).with('/redfish/v1/Managers/2/EthernetInterfaces/2/', body: @body).and_return(FakeResponse.new)
-      expect(@client.set_ilo_hostname('server-ilo', nil, 2, 2)).to eq(true)
+      expect(@client.set_ilo_hostname(hostname: 'server-ilo', manager_id: 2, ethernet_interface: 2)).to eq(true)
     end
   end
 end


### PR DESCRIPTION
I've added a few simple helpers for the configuration of IPv4 parameters.

**methods:**
`get_ilo_ethernet_interface `
`set_ilo_ipv4_dhcp` set iLO to obtain everything from DHCP (IPv4 stack)
`set_ilo_ipv4_static` set static IPv4 address, mask and gateway
`set_ilo_ipv4_dns_servers` set DNS servers
`set_ilo_hostname` set iLO hostname and domain name

**Open topics:**
- [x] unit tests
- [x] documentation (if needed)

